### PR TITLE
remove nod and shuffle FPUs (for now)

### DIFF
--- a/src/main/scala/search/Search.scala
+++ b/src/main/scala/search/Search.scala
@@ -4,7 +4,7 @@
 package basic
 package search
 
-import cats.implicits._
+import basic.syntax.all._
 import gem.enum._
 
 object Search {
@@ -21,7 +21,10 @@ object Search {
     // for each instrument (at the cost of dealing with some large sets in memory).
 
     val gmosNorthModes: List[ObservingMode.Spectroscopy] =
-      (GmosNorthDisperser.all, GmosNorthFpu.all).mapN(ObservingMode.Spectroscopy.GmosNorth)
+      for {
+        disp <- GmosNorthDisperser.all
+        fpu  <- GmosNorthFpu.all.filterNot(_.isNodAndShuffle) // don't consider for now
+      } yield ObservingMode.Spectroscopy.GmosNorth(disp, fpu)
 
     // more instruments ...
 

--- a/src/main/scala/syntax/GmosNorthFpu.scala
+++ b/src/main/scala/syntax/GmosNorthFpu.scala
@@ -31,6 +31,26 @@ final class GmosNorthFpuOps(val self: GmosNorthFpu) extends AnyVal {
       case LongSlit_5_00 => 5.00
     }
 
+  def isNodAndShuffle: Boolean =
+    self match {
+      case Ifu1          => false
+      case Ifu2          => false
+      case Ifu3          => false
+      case Ns0           => true
+      case Ns1           => true
+      case Ns2           => true
+      case Ns3           => true
+      case Ns4           => true
+      case Ns5           => true
+      case LongSlit_0_25 => false
+      case LongSlit_0_50 => false
+      case LongSlit_0_75 => false
+      case LongSlit_1_00 => false
+      case LongSlit_1_50 => false
+      case LongSlit_2_00 => false
+      case LongSlit_5_00 => false
+    }
+
 }
 
 trait ToGmosNorthFpuOps {


### PR DESCRIPTION
We can't yet do ITC calculations for GMOS nod and shuffle so I'm removing those FPUs from consideration for now.