### PR TITLE
Longslit sequence updates

### DIFF
--- a/src/main/scala/gen/gmos/GmosNLongslit.scala
+++ b/src/main/scala/gen/gmos/GmosNLongslit.scala
@@ -92,7 +92,7 @@ object GmosNLongslit {
             _  <- GmosN.xBinning     := xbin(mode.fpu)
             _  <- GmosN.yBinning     := GmosYBinning.Two
             _  <- GmosN.grating      := Some(GmosGrating(mode.disperser, GmosDisperserOrder.One, mode.λ))
-            // _  <- GmosN.filter       := tbd
+            _  <- GmosN.filter       := mode.filter
             _  <- GmosN.fpu          := Some(Right(mode.fpu))
             s0 <- scienceStep(0.arcsec, 0.arcsec)
             f0 <- smartFlatStep

--- a/src/main/scala/gen/gmos/GmosNLongslitD.scala
+++ b/src/main/scala/gen/gmos/GmosNLongslitD.scala
@@ -146,13 +146,16 @@ object GmosNLongslitD {
         // distinguish acquisition from science.
         val t = itc.integrationTime(mode, magnitude)
 
+        // An effect that computes the "through-slit image" part of acqusition.
+        val slitImage = exposureTime.evalSet(t.map(_ * 4))(steps.s2)
+
         // Runs step s0 (with exposure time from ITC), s1, and then continually
         // repeates s2 (with continually updated exposure time from ITC) until
         // acquisition is complete.
         Stream.eval(exposureTime.evalSet(t)(steps.s0)) ++
           Stream(steps.s1)                             ++
-          Stream.repeatEval(exposureTime.evalSet(t.map(_ * 4))(steps.s2))
-                .evalTakeWhileNot(acquired)
+          Stream.eval(slitImage)                       ++
+          Stream.repeatEval(slitImage).evalTakeWhileNot(acquired)
 
       }
 

--- a/src/main/scala/gen/gmos/GmosNLongslitD.scala
+++ b/src/main/scala/gen/gmos/GmosNLongslitD.scala
@@ -13,7 +13,7 @@ import gem.enum._
 import gem.math.{ MagnitudeValue, Wavelength }
 
 import cats.Functor
-import cats.effect.Sync
+import cats.effect.{ Sync, Timer }
 import cats.implicits._
 import fs2.Stream
 import monocle.{Prism, Optional}
@@ -29,25 +29,102 @@ import scala.concurrent.duration.FiniteDuration
 sealed trait GmosNLongslitD[F[_]] {
 
   /**
-   * Generates a sequence that is as long as necessary to achieve the desired
-   * s/n ratio.  Integration time is adjusted throughout to match conditions.
+   * Generates an acquisition sequence which terminates when the provided
+   * `acquired` effect evaluates `true`.
    *
    * @param itc integration time calculator
-   * @param acquired a program that can be evaluated to determine whether an
-   *                 acquisition (or reacquisition) is necessary
+   * @param acquired a program that can be evaluated to determine whether the
+   *                 acquisition has completed
+   *
+   * @return a sequence that acquires the target
+   */
+  def acquisition(
+    itc:      Itc[F],
+    acquired: F[Boolean]
+  ): Stream[F, Step.GmosN]
+
+  /**
+   * Generates a reacquisition sequence which terminates when the provided
+   * `acquired` effect evaluates `true`.  This is appropriate for guiding with
+   * PWFS options.
+   *
+   * @param itc integration time calculator
+   * @param acquired a program that can be evaluated to determine whether the
+   *                 reacquisition has completed
+   *
+   * @return a sequence that reacquires the target
+   */
+  def reacquisition(
+    itc:      Itc[F],
+    acquired: F[Boolean]
+  ): Stream[F, Step.GmosN]
+
+  /**
+   * Generates a science sequence which terminates when the provided `reachedS2N`
+   * effect evalutes `true`. Computes the science sequence as a stream of
+   * "science/flat" "atoms" where the offset in Q and observing wavelength vary.
+   *
+   * @param itc integration time calculator
    * @param reachedS2N a program that can be evaluated to determine whether the
    *                   desired s/n ratio has been reached
-   * @tparam F effect
+   *
+   * @return a science sequence that termines when the desired s/n ratio is
+   *         achieved
+   */
+  def science(
+    itc:        Itc[F],
+    reachedS2N: F[Boolean]
+  ): Stream[F, Stream[F, Step.GmosN]]
+
+  /**
+   * Generates a sequence, including initial acquisition and reacquisition as
+   * necessary, that is as long as necessary to achieve the desired s/n ratio.
+   * Integration time is adjusted throughout to match conditions.  This version
+   * combines `acquisition`, `reacquisition`, and `science` into a single
+   * complete sequence.  Since it includes reacquisition, this version is
+   * appropriate for guiding with PWFS options.
+   *
+   * @param itc integration time calculator
+   * @param acquired a program that can be evaluated to determine whether the
+   *                 acquisition has completed
+   * @param reachedS2N a program that can be evaluated to determine whether the
+   *                   desired s/n ratio has been reached
+   * @param reacquirePeriod perform a reacquire every time this period passes
    *
    * @return a sequence that acquires (and reacquires as necessary) the target
    *         and collects science data and calibrations until the desired s/n
    *         ratio is achieved
    */
-  def sequence(
-    itc:        Itc[F],
-    acquired:   F[Boolean],
-    reachedS2N: F[Boolean]
+  def sequenceWithReacquisition(
+    itc:             Itc[F],
+    acquired:        F[Boolean],
+    reachedS2N:      F[Boolean],
+    reacquirePeriod: FiniteDuration
   ): Stream[F, Step.GmosN]
+
+  /**
+   * Generates a sequence, including the initial acquisition, that is as long as
+   * necessary to achieve the desired s/n ratio.  Integration time is adjusted
+   * throughout to match conditions. This version combines `acquisition` and
+   * `science` into a single complete sequence. It omits `reacquisition` to
+   * provide an alternative when OI is used for guiding.
+   *
+   * @param itc integration time calculator
+   * @param acquired a program that can be evaluated to determine whether an
+   *                 the acquisition has completed
+   * @param reachedS2N a program that can be evaluated to determine whether the
+   *                   desired s/n ratio has been reached
+   * @param reacquirePeriod perform a reacquire every time this period passes
+   *
+   * @return a sequence that acquires the target and collects science data and
+   *         calibrations until the desired s/n ratio is achieved
+   */
+  def sequence(
+    itc:             Itc[F],
+    acquired:        F[Boolean],
+    reachedS2N:      F[Boolean]
+  ): Stream[F, Step.GmosN] =
+    sequenceWithReacquisition(itc, acquired, reachedS2N, FiniteDuration(Long.MaxValue, NANOSECONDS))
 
 }
 
@@ -94,110 +171,164 @@ object GmosNLongslitD {
 
   }
 
-  def apply[F[_]: Sync](
+  /**
+   * Unique step configurations used to form an acquisition sequence. Steps
+   * `ccd2` and `slit` are missing exposure time which must be set based upon
+   * ITC calculations.
+   *
+   * @param ccd2 initial image with CCD2 ROI
+   * @param p10  image through the slit at offset p 10
+   * @param slit image through the slit
+   */
+  final case class AcquisitionSteps(
+    ccd2: Step.GmosN,
+    p10:  Step.GmosN,
+    slit: Step.GmosN
+  )
+
+  object AcquisitionSteps extends GmosNOps {
+
+    // Find the filter with the closest wavelength.
+    private def filter(mode: ObservingMode.Spectroscopy.GmosNorth): GmosNorthFilter =
+      GmosNorthFilter.allAcquisition.minBy { f =>
+        (mode.λ.toPicometers - f.wavelength.toPicometers).abs
+      }
+
+    /**
+     * Creates an AcquisitionSteps from the observing mode.
+     */
+    def apply(mode: ObservingMode.Spectroscopy.GmosNorth): AcquisitionSteps =
+      eval {
+        for {
+          _  <- GmosN.filter       := Some(filter(mode))
+          _  <- GmosN.fpu          := None
+          _  <- GmosN.grating      := None
+          _  <- GmosN.xBinning     := GmosXBinning.Two
+          _  <- GmosN.yBinning     := GmosYBinning.Two
+          _  <- GmosN.roi          := GmosRoi.Ccd2
+          s0 <- scienceStep(0.arcsec, 0.arcsec)
+
+          _  <- GmosN.exposureTime := 20.seconds
+          _  <- GmosN.fpu          := Some(Right(mode.fpu))
+          _  <- GmosN.xBinning     := GmosXBinning.One
+          _  <- GmosN.yBinning     := GmosYBinning.One
+          _  <- GmosN.roi          := GmosRoi.CentralStamp
+          s1 <- scienceStep(10.arcsec, 0.arcsec)
+
+          s2 <- scienceStep(0.arcsec, 0.arcsec)
+        } yield AcquisitionSteps(s0, s1, s2)
+      }
+
+  }
+
+  /**
+   * Unique step configurations used to form a science sequence. The science
+   * steps are missing exposure time which must be set via ITC calculations.
+   *
+   * @param science0 science step at offset (0, 0) and requested λ
+   * @param flat0    smart flat matching `science0`
+   * @param science1 science step at offset (0, 15) and λ + Δ
+   * @param flat1    smart flat matching `science1`
+   */
+  final case class ScienceSteps(
+    science0: Step.GmosN, // ((0, 0), λ)
+    flat0:    Step.GmosN,
+    science1: Step.GmosN, // ((0, 15), λ + Δ)
+    flat1:    Step.GmosN
+  )
+
+  object ScienceSteps extends GmosNOps with GmosLongslitMath {
+
+    // Adds two wavelength values. This is unsafe in general because of the
+    // possibility of overflow.  Here we know that Δ is at most 30 nm and λ is
+    // a reasonable observing wavelength so it cannot fail.  He he.
+    private def sum(λ: Wavelength, Δ: Wavelength): Wavelength = {
+      import gem.syntax.prism._
+      Wavelength.fromPicometers.unsafeGet(λ.toPicometers + Δ.toPicometers)
+    }
+
+    /**
+     * Creates ScienceSteps from the observing mode.
+     */
+    def apply(mode: ObservingMode.Spectroscopy.GmosNorth): ScienceSteps =
+      eval {
+        for {
+          _  <- GmosN.xBinning     := xbin(mode.fpu)
+          _  <- GmosN.yBinning     := GmosYBinning.Two
+          _  <- GmosN.grating      := Some(GmosGrating(mode.disperser, GmosDisperserOrder.One, mode.λ))
+          _  <- GmosN.filter       := mode.filter
+          _  <- GmosN.fpu          := Some(Right(mode.fpu))
+          s0 <- scienceStep(0.arcsec, 0.arcsec)
+          f0 <- smartFlatStep
+
+          _  <- GmosN.wavelength   := sum(mode.λ, Δλ(mode.disperser))
+          s1 <- scienceStep(0.arcsec, 15.arcsec)
+          f1 <- smartFlatStep
+        } yield ScienceSteps(s0, f0, s1, f1)
+      }
+
+  }
+
+  def apply[F[_]: Sync : Timer](
     mode:      ObservingMode.Spectroscopy.GmosNorth,
     magnitude: MagnitudeValue
   ): GmosNLongslitD[F] =
 
     new GmosNLongslitD[F] with GmosNOps with GmosLongslitMath {
 
+      val emptySequence: Stream[F, Step.GmosN] =
+        Stream.empty.covaryAll[F, Step.GmosN]
+
+      // This is a placeholder for the integration time lookup.  It will
+      // surely need other parameters for current conditions and to
+      // distinguish acquisition from science.
+      def acquisitionTime(itc: Itc[F]): F[FiniteDuration] =
+        itc.integrationTime(mode, magnitude)
+
       // Computes the acquisition sequence, which terminates after 2 or more
       // steps when the provided `acquired` effect evaluates `true`.
-      private def acquisition(
+      override def acquisition(
         itc:      Itc[F],
         acquired: F[Boolean]
       ): Stream[F, Step.GmosN] = {
 
-        // Find the filter with the closest wavelength.
-        val filter = GmosNorthFilter.allAcquisition.minBy { f =>
-          (mode.λ.toPicometers - f.wavelength.toPicometers).abs
-        }
+        val steps = AcquisitionSteps(mode)
 
-        // Names the 3 unique configurations that are required.
-        final case class Steps(
-          s0: Step.GmosN,
-          s1: Step.GmosN,
-          s2: Step.GmosN
-        )
-
-        val steps: Steps = eval {
-          for {
-            _  <- GmosN.filter       := Some(filter)
-            _  <- GmosN.fpu          := None
-            _  <- GmosN.grating      := None
-            _  <- GmosN.xBinning     := GmosXBinning.Two
-            _  <- GmosN.yBinning     := GmosYBinning.Two
-            _  <- GmosN.roi          := GmosRoi.Ccd2
-            s0 <- scienceStep(0.arcsec, 0.arcsec)
-
-            _  <- GmosN.exposureTime := 20.seconds
-            _  <- GmosN.fpu          := Some(Right(mode.fpu))
-            _  <- GmosN.xBinning     := GmosXBinning.One
-            _  <- GmosN.yBinning     := GmosYBinning.One
-            _  <- GmosN.roi          := GmosRoi.CentralStamp
-            s1 <- scienceStep(10.arcsec, 0.arcsec)
-
-            s2 <- scienceStep(0.arcsec, 0.arcsec)
-          } yield Steps(s0, s1, s2)
-        }
-
-        // This is a placeholder for the integration time lookup.  It will
-        // surely need other parameters for current conditions and to
-        // distinguish acquisition from science.
-        val t = itc.integrationTime(mode, magnitude)
-
-        // An effect that computes the "through-slit image" part of acqusition.
-        val slitImage = exposureTime.evalSet(t.map(_ * 4))(steps.s2)
+        // An effect that computes the initial CCD2 image step.
+        val ccd2: F[Step.GmosN] =
+          exposureTime.evalSet(acquisitionTime(itc))(steps.ccd2)
 
         // Runs step s0 (with exposure time from ITC), s1, and then continually
         // repeates s2 (with continually updated exposure time from ITC) until
         // acquisition is complete.
-        Stream.eval(exposureTime.evalSet(t)(steps.s0)) ++
-          Stream(steps.s1)                             ++
-          Stream.eval(slitImage)                       ++
+        Stream.eval(ccd2)              ++
+          Stream(steps.p10)            ++
+          reacquisition(itc, acquired)
+
+      }
+
+      override def reacquisition(
+        itc:      Itc[F],
+        acquired: F[Boolean]
+      ): Stream[F, Step.GmosN] = {
+
+        val steps = AcquisitionSteps(mode)
+
+        // An effect that computes the "through-slit image" part of acqusition.
+        val slitImage: F[Step.GmosN] =
+          exposureTime.evalSet(acquisitionTime(itc).map(_ * 4))(steps.slit)
+
+        Stream.eval(slitImage) ++
           Stream.repeatEval(slitImage).evalTakeWhileNot(acquired)
 
       }
 
-      // Computes the science sequence as a stream of "science/flat" "atoms"
-      // where the offset in Q and observing wavelength vary. Continues until
-      // the provided `reachedS2N` effect evalues `true`.
-      private def science(
+      override def science(
         itc:        Itc[F],
         reachedS2N: F[Boolean]
       ): Stream[F, Stream[F, Step.GmosN]] = {
 
-        // Adds two wavelength values. This is unsafe in general because of the
-        // possibility of overflow.  Here we know that Δ is at most 30 nm and λ is
-        // a reasonable observing wavelength so it cannot fail.  He he.
-        def sum(λ: Wavelength, Δ: Wavelength): Wavelength = {
-          import gem.syntax.prism._
-          Wavelength.fromPicometers.unsafeGet(λ.toPicometers + Δ.toPicometers)
-        }
-
-        // Names the 4 unique configurations that are required.
-        final case class Steps(
-          science0: Step.GmosN, // ((0, 0), λ)
-          flat0:    Step.GmosN,
-          science1: Step.GmosN, // ((0, 15), λ + Δ)
-          flat1:    Step.GmosN
-        )
-
-        val steps: Steps = eval {
-          for {
-            _  <- GmosN.xBinning     := xbin(mode.fpu)
-            _  <- GmosN.yBinning     := GmosYBinning.Two
-            _  <- GmosN.grating      := Some(GmosGrating(mode.disperser, GmosDisperserOrder.One, mode.λ))
-            _  <- GmosN.filter       := mode.filter
-            _  <- GmosN.fpu          := Some(Right(mode.fpu))
-            s0 <- scienceStep(0.arcsec, 0.arcsec)
-            f0 <- smartFlatStep
-
-            _  <- GmosN.wavelength   := sum(mode.λ, Δλ(mode.disperser))
-            s1 <- scienceStep(0.arcsec, 15.arcsec)
-            f1 <- smartFlatStep
-          } yield Steps(s0, f0, s1, f1)
-        }
+        val steps = ScienceSteps(mode)
 
         // A mini stream containing two steps, one a science dataset and the
         // other a smart flat.  These shouldn't be broken up by acquisition so
@@ -219,31 +350,25 @@ object GmosNLongslitD {
 
       }
 
-      private val emptySequence: Stream[F, Step.GmosN] =
-        Stream.empty.covaryAll[F, Step.GmosN]
-
-      override def sequence(
-        itc:        Itc[F],
-        acquired:   F[Boolean],
-        reachedS2N: F[Boolean]
+      override def sequenceWithReacquisition(
+        itc:             Itc[F],
+        acquired:        F[Boolean],
+        reachedS2N:      F[Boolean],
+        reacquirePeriod: FiniteDuration
       ): Stream[F, Step.GmosN] = {
 
-        // The raw acquisition sequence
-        val acqSequence: Stream[F, Step.GmosN] =
-          acquisition(itc, acquired)
-
         // An infinite Stream[F, Stream[F, Step.GmosN]] where at each step we
-        // check whether an acquisition is necessary and output an empty Stream
-        // if not, or else an acquisition sequence if so.
+        // check whether a reacquisition is necessary
         val reacquireAsNecessary: Stream[F, Stream[F, Step.GmosN]] =
-          Stream.repeatEval {
-            acquired.map { a => if (a) emptySequence else acqSequence }
-          }.cons1(acqSequence) // always do an acquisition sequence at first
+          Stream.every[F](reacquirePeriod).drop(1).map { doReacq =>
+            if (doReacq) reacquisition(itc, acquired) else emptySequence
+          }
 
         // Executes the science stream for as long as necessary to reach desired
         // signal to noise, performing (re)acquisitions between "atoms" as
         // necessary.
-        (reacquireAsNecessary.zipWith(science(itc, reachedS2N))(_ ++ _)).flatten
+        acquisition(itc, acquired) ++
+          (reacquireAsNecessary.zipWith(science(itc, reachedS2N))(_ ++ _)).flatten
       }
 
 

--- a/src/main/scala/gen/gmos/GmosNLongslitD.scala
+++ b/src/main/scala/gen/gmos/GmosNLongslitD.scala
@@ -185,7 +185,7 @@ object GmosNLongslitD {
             _  <- GmosN.xBinning     := xbin(mode.fpu)
             _  <- GmosN.yBinning     := GmosYBinning.Two
             _  <- GmosN.grating      := Some(GmosGrating(mode.disperser, GmosDisperserOrder.One, mode.λ))
-            // _  <- GmosN.filter       := tbd
+            _  <- GmosN.filter       := mode.filter
             _  <- GmosN.fpu          := Some(Right(mode.fpu))
             s0 <- scienceStep(0.arcsec, 0.arcsec)
             f0 <- smartFlatStep


### PR DESCRIPTION
Updates the sequence generation to set the filter from the observing mode and update the "dynamic" case reacquisition logic.  Reacquisition is a subset of the full acquisition which wasn't appreciated before.  Also, reacquisition happens after a fixed duration has passed so there is no need to run an arbitrary effect to check whether it is necessary.

Note for now I still have the fixed (infinite) sequence version and the dynamic version but ultimately we should only need one of them.  Presumably, the dynamic version.