### PR TITLE
Sequence ITC update

### DIFF
--- a/src/main/scala/Itc.scala
+++ b/src/main/scala/Itc.scala
@@ -3,21 +3,7 @@
 
 package basic
 
-import gem.math.MagnitudeValue
 import scala.concurrent.duration.FiniteDuration
-
-// TODO: replace this with real Itc down in the sequence code
-trait ImaginaryItc[F[_]] {
-
-  def integrationTime(
-    mode:      ObservingMode,
-    magnitude: MagnitudeValue,
-    // what else do we need?
-  ): F[FiniteDuration]
-
-}
-
-
 
 trait Itc[F[_]] {
 

--- a/src/main/scala/gen/gmos/GmosNLongslitD.scala
+++ b/src/main/scala/gen/gmos/GmosNLongslitD.scala
@@ -129,10 +129,10 @@ object GmosNLongslitD {
     val Max: Duration =
       Duration.ofNanos(Long.MaxValue)
 
-    def toFiniteDuration(d: Duration): Option[FiniteDuration] =
+    private def toFiniteDuration(d: Duration): Option[FiniteDuration] =
       Some(d).filter(_.compareTo(Max) <= 0).as(FiniteDuration(d.toMillis, NANOSECONDS))
 
-    def toDuration(fd: FiniteDuration): Duration =
+    private def toDuration(fd: FiniteDuration): Duration =
       Duration.ofNanos(fd.toNanos)
 
     // Converter between Java and Scala durations.

--- a/src/test/scala/gen/gmos/Demo.scala
+++ b/src/test/scala/gen/gmos/Demo.scala
@@ -1,0 +1,109 @@
+// Copyright (c) 2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package basic
+package gen.gmos
+
+import gem.Step
+import gem.enum._
+import gem.enum.GmosNorthDisperser.R831_G5302
+import gem.enum.GmosNorthFilter.GG455
+import gem.enum.GmosNorthFpu.LongSlit_0_75
+import gem.math.Wavelength
+import basic.misc._
+
+import cats.implicits._
+import cats.effect.{ ExitCode, IO, IOApp }
+import cats.effect.concurrent.Ref
+
+import fs2.Stream
+
+import scala.concurrent.duration._
+import scala.language.postfixOps
+import scala.util.Random
+
+/**
+ * GmosN Longslit Sequence generation demonstration.
+ */
+object Demo extends IOApp {
+
+  // A stand-in ITC that just picks from among three possible results at random.
+  val dummyItc: Itc[IO] =
+    new Itc[IO] {
+      override def calculate(
+        targetProfile: TargetProfile,
+        observingMode: ObservingMode,
+        signalToNoise: Int
+      ): IO[Itc.Result] =
+        IO {
+          Random.nextInt(3) match {
+            case 0 => Itc.Result.Success(1200 seconds, 14, 1022)
+            case 1 => Itc.Result.Success(1100 seconds, 13, 1003)
+            case _ => Itc.Result.Success(1000 seconds, 12, 1017)
+          }
+        }
+    }
+
+  // Needed to call the ITC but not really used.
+  val dummyTargetProfile: TargetProfile =
+    TargetProfile(
+      SpatialProfile.PointSource,
+      SpectralDistribution.PowerLaw(1.0),
+      1.0,
+      MagnitudeSystem.Vega,
+      MagnitudeBand.R,
+      Redshift(1.0)
+    )
+
+  // The example basic-case observing mode.
+  val observingMode: ObservingMode.Spectroscopy.GmosNorth =
+    ObservingMode.Spectroscopy.GmosNorth(
+      Wavelength.fromNanometers.getOption(600).get,
+      R831_G5302,
+      LongSlit_0_75,
+      Some(GG455)
+    )
+
+  // A coin flip after each "image through the slit" to decide whether we're
+  // done with the acquisition.
+  val acquired: IO[Boolean] =
+    IO(Random.nextBoolean())
+
+  // Sequence state.
+  final case class Database(acc: Double, steps: Vector[(Step.GmosN, Double)]) {
+
+    def +(step: Step.GmosN, stepSn: Double): Database =
+      Database(acc + stepSn * stepSn, steps :+ ((step, stepSn)))
+
+    def totalSn: Double =
+      math.sqrt(acc)
+
+  }
+
+  object Database {
+
+    val zero: Database =
+      Database(0.0, Vector.empty)
+
+  }
+
+  def run(args: List[String]): IO[ExitCode] = {
+
+    val db: Ref[IO, Database] =
+      Ref.unsafe(Database.zero)
+
+    def reachedS2N(goal: Int): IO[Boolean] =
+      db.get.map { _.totalSn >= goal.toDouble }
+
+    SequenceFormat.printHeader *>
+      IO(println(" S/N"))      *>
+      GmosNLongslitD(dummyItc, dummyTargetProfile, observingMode, 1000)
+        .sequence(acquired, reachedS2N)
+        .zipLeft(Stream.awakeDelay[IO](1 seconds)) // pause a bit between steps
+        .evalTap[IO] { case (s, sn) => db.update(_ + (s, sn)) }
+        .evalTap[IO] { case (s, _ ) => SequenceFormat.printStep(s) *> db.get.map(d => println(f" ${d.totalSn}%6.1f")) }
+        .compile
+        .drain
+        .as(ExitCode.Success)
+  }
+}

--- a/src/test/scala/gen/gmos/SequenceFormat.scala
+++ b/src/test/scala/gen/gmos/SequenceFormat.scala
@@ -1,0 +1,168 @@
+// Copyright (c) 2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package basic
+package gen.gmos
+
+import gem.Step
+import gem.Step.Base
+import gem.Step.Base.SmartGcal
+import gem.config.DynamicConfig.GmosN
+import gem.config.TelescopeConfig
+import gem.enum._
+import gem.math.{ Angle, Wavelength }
+import gem.math.Offset.{P, Q}
+
+import cats.effect.IO
+
+import monocle.std.option.some
+import monocle.{Lens, Optional}
+
+import java.time.Duration
+
+
+/**
+ * Throwaway code for formatting sequence into a table.
+ */
+object SequenceFormat {
+
+  final case class Column[A](
+    name:         String,
+    getter:       Step.GmosN => Option[A],
+    format:       A => String,
+    size:         Int = 10,
+    rightJustify: Boolean = false
+  ) {
+    def formatStep: Step.GmosN => Option[String] =
+      s => getter(s).map(format)
+  }
+
+  private def optional[A](o: Optional[GmosN, A]): Step.GmosN => Option[A] =
+    (Step.GmosN.dynamicConfig composeOptional o).getOption(_)
+
+  private def lens[A](l: Lens[GmosN, A]): Step.GmosN => Option[A] =
+    s => Some((Step.GmosN.dynamicConfig composeLens l).get(s))
+
+  private val stepType: Column[Base] = Column(
+    "Type",
+    s => Some(Step.GmosN.base.get(s)),
+    {
+      case Base.Bias         => "Bias"
+      case Base.Dark         => "Dark"
+      case Base.Gcal(_)      => "GCAL"
+      case Base.Science(_)   => ""
+      case Base.SmartGcal(t) => s"Smart ${t.tag}"
+    },
+    10
+  )
+
+  private val fpu: Column[GmosNorthFpu] = Column(
+    "FPU",
+    optional(GmosN.builtinFpu),
+    _.shortName,
+    10
+  )
+
+  private val disperser: Column[GmosNorthDisperser] = Column(
+    "Disperser",
+    optional(GmosN.disperser),
+    _.shortName,
+    9
+  )
+
+  private val filter: Column[GmosNorthFilter] = Column(
+    "Filter",
+    optional(GmosN.filter composePrism some),
+    _.shortName,
+    7
+  )
+
+  private val wavelength: Column[Wavelength] = Column(
+    "λ (nm)",
+    optional(GmosN.wavelength),
+    w => Wavelength.fromNanometers.reverseGet(w).toString,
+    6,
+    rightJustify = true
+  )
+
+  private val exposureTime: Column[Duration] = Column(
+    "Secs",
+    {
+      case Step.GmosN(_, SmartGcal(_)) => None
+      case Step.GmosN(dyn, _) => Some(GmosN.exposureTime.get(dyn))
+    },
+    _.getSeconds.toString,
+    4,
+    rightJustify = true
+  )
+
+  private val xbin: Column[GmosXBinning] = Column(
+    "Xbin",
+    lens(GmosN.xBinning),
+    _.shortName,
+    4,
+    rightJustify = true
+  )
+
+  private val ybin: Column[GmosYBinning] = Column(
+    "Ybin",
+    lens(GmosN.yBinning),
+    _.shortName,
+    4,
+    rightJustify = true
+  )
+
+  private val roi: Column[GmosRoi] = Column(
+    "ROI",
+    lens(GmosN.roi),
+    _.shortName,
+    5
+  )
+
+  private val p: Column[P] = Column(
+    "p",
+    (Step.GmosN.base composePrism Base.telescopeConfig composeLens TelescopeConfig.p).getOption(_),
+    p => f"${Angle.signedArcseconds.get(p.toAngle)}%.1f",
+    4,
+    rightJustify = true
+  )
+
+  private val q: Column[Q] = Column(
+    "q",
+    (Step.GmosN.base composePrism Base.telescopeConfig composeLens TelescopeConfig.q).getOption(_),
+    q => f"${Angle.signedArcseconds.get(q.toAngle)}%.1f",
+    4,
+    rightJustify = true
+  )
+
+  private val columns = List(
+    stepType,
+    fpu,
+    disperser,
+    filter,
+    wavelength,
+    exposureTime,
+    xbin,
+    ybin,
+    roi,
+    p,
+    q
+  )
+
+  def formatHeader: String =
+    columns.map(c => String.format(s"%-${c.size}s", c.name)).mkString("| ", " | ", " |")
+
+  def printHeader: IO[Unit] =
+    IO(print(formatHeader))
+
+  def formatStep(s: Step.GmosN): String =
+    columns.map { c =>
+      val fmt = s"%${if (c.rightJustify) "" else "-"}${c.size}s"
+
+      String.format(fmt, c.formatStep(s).getOrElse(""))
+    }.mkString("| ", " | ", " |")
+
+  def printStep(s: Step.GmosN): IO[Unit] =
+    IO(print(formatStep(s)))
+
+}


### PR DESCRIPTION
Removes the `ImaginaryItc` and updates the dynamic sequence generation code to use the new `Itc` interface.  The bulk of this PR is demo code necessary to produce an [updated demo](https://www.dropbox.com/s/vezj2hq1zdgh1sl/Screen%20Recording%202019-03-22%20at%2017.26.57.mov?dl=0).

The sequence continues to be a work in progress, so this should be seen as a progress snapshot.  I'll make a few notes in the code about pending work.