### PR TITLE
Convert Gaussian fwhm to Angle

### DIFF
--- a/src/main/scala/itc/ItcSourceDefinition.scala
+++ b/src/main/scala/itc/ItcSourceDefinition.scala
@@ -48,9 +48,12 @@ object ItcSourceDefinition {
       import SpatialProfile._
       def apply(a: SpatialProfile): Json =
         a match {
-          case PointSource          => Json.obj("PointSource"    -> Json.obj())
-          case UniformSource        => Json.obj("UniformSource"  -> Json.obj())
-          case GaussianSource(fwhm) => Json.obj("GaussianSource" -> Json.obj("fwhm" -> Json.fromDoubleOrNull(fwhm)))
+          case PointSource           => Json.obj("PointSource"    -> Json.obj())
+          case UniformSource         => Json.obj("UniformSource"  -> Json.obj())
+          case g @ GaussianSource(_) =>
+            Json.obj(
+              "GaussianSource" -> Json.obj("fwhm" -> Json.fromDoubleOrNull(GaussianSource.arcsec.get(g).toDouble))
+            )
         }
     }
 

--- a/src/main/scala/misc/SpatialProfile.scala
+++ b/src/main/scala/misc/SpatialProfile.scala
@@ -3,9 +3,40 @@
 
 package basic.misc
 
+import gem.math.Angle
+import gem.optics.SplitMono
+
 sealed trait SpatialProfile
+
 object SpatialProfile {
-  final case object PointSource                  extends SpatialProfile
-  final case object UniformSource                extends SpatialProfile
-  final case class  GaussianSource(fwhm: Double) extends SpatialProfile
+  final case object PointSource                 extends SpatialProfile
+  final case object UniformSource               extends SpatialProfile
+
+  /**
+   * Gaussian source. For a good discussion of seeing see the
+   * ["Astronomical seeing" wikipedia entry](https://en.wikipedia.org/wiki/Astronomical_seeing).
+   *
+   * @param fwhm full width at half maximum of the seeing disc (typically
+   *             in arcsec)
+   */
+  final case class  GaussianSource(fwhm: Angle) extends SpatialProfile
+
+  object GaussianSource extends GaussianSourceOptics
+
+  trait GaussianSourceOptics {
+
+    /**
+     * Conversion between GaussianSource and arcsec of the FWHM of the seeing
+     * disc.
+     *
+     * @group Optics
+     */
+    val arcsec: SplitMono[GaussianSource, BigDecimal] =
+      SplitMono(
+        g => new java.math.BigDecimal(g.fwhm.toMicroarcseconds).movePointLeft(6),
+        d => GaussianSource(Angle.fromMicroarcseconds(d.underlying.movePointRight(6).longValue))
+      )
+
+  }
 }
+

--- a/src/main/scala/syntax/GmosNorthDisperser.scala
+++ b/src/main/scala/syntax/GmosNorthDisperser.scala
@@ -5,7 +5,7 @@ package basic.syntax
 
 import gem.enum.GmosNorthDisperser
 import gem.enum.GmosNorthDisperser._
-import gem.math.Wavelength
+import gem.math.{ Angle, Wavelength }
 
 /**
  * Syntax extensions for missing properties. These need to be folded back into the Gem enumerations.
@@ -38,8 +38,8 @@ final class GmosNorthDisperserOps(val self: GmosNorthDisperser) extends AnyVal {
   }
 
   /** Resolution at λ with the specified slit width (arcsec). */
-  def resolution(λ: Wavelength, slitWidth: Double): Int =
-    ((Wavelength.fromNanometers.reverseGet(λ) / Δλ) * (0.5 / slitWidth)).toInt
+  def resolution(λ: Wavelength, slitWidth: Angle): Int =
+    ((Wavelength.fromNanometers.reverseGet(λ) / Δλ) * (0.5 / Angle.signedArcseconds.get(slitWidth))).toInt
 
   /**
    * Simultaneous coverage with Hamamatsu detectors.

--- a/src/main/scala/syntax/GmosNorthFpu.scala
+++ b/src/main/scala/syntax/GmosNorthFpu.scala
@@ -6,29 +6,31 @@ package basic.syntax
 import gem.enum.GmosNorthFpu
 import gem.enum.GmosNorthFpu._
 
+import gem.math.Angle
+
 /**
  * Syntax extensions for missing properties. These need to be folded back into the Gem enumerations.
  */
 final class GmosNorthFpuOps(val self: GmosNorthFpu) extends AnyVal {
 
-  def effectiveSlitWidth: Double =
+  def effectiveSlitWidth: Angle =
     self match {
-      case Ifu1          => 0.31
-      case Ifu2          => 0.31
-      case Ifu3          => 0.31
-      case Ns0           => 0.25
-      case Ns1           => 0.50
-      case Ns2           => 0.75
-      case Ns3           => 1.00
-      case Ns4           => 1.50
-      case Ns5           => 2.00
-      case LongSlit_0_25 => 0.25
-      case LongSlit_0_50 => 0.50
-      case LongSlit_0_75 => 0.75
-      case LongSlit_1_00 => 1.00
-      case LongSlit_1_50 => 1.50
-      case LongSlit_2_00 => 2.00
-      case LongSlit_5_00 => 5.00
+      case Ifu1          => Angle.fromMicroarcseconds( 310000)
+      case Ifu2          => Angle.fromMicroarcseconds( 310000)
+      case Ifu3          => Angle.fromMicroarcseconds( 310000)
+      case Ns0           => Angle.fromMicroarcseconds( 250000)
+      case Ns1           => Angle.fromMicroarcseconds( 500000)
+      case Ns2           => Angle.fromMicroarcseconds( 750000)
+      case Ns3           => Angle.fromMicroarcseconds(1000000)
+      case Ns4           => Angle.fromMicroarcseconds(1500000)
+      case Ns5           => Angle.fromMicroarcseconds(2000000)
+      case LongSlit_0_25 => Angle.fromMicroarcseconds( 250000)
+      case LongSlit_0_50 => Angle.fromMicroarcseconds( 500000)
+      case LongSlit_0_75 => Angle.fromMicroarcseconds( 750000)
+      case LongSlit_1_00 => Angle.fromMicroarcseconds(1000000)
+      case LongSlit_1_50 => Angle.fromMicroarcseconds(1500000)
+      case LongSlit_2_00 => Angle.fromMicroarcseconds(2000000)
+      case LongSlit_5_00 => Angle.fromMicroarcseconds(5000000)
     }
 
   def isNodAndShuffle: Boolean =


### PR DESCRIPTION
Updates the `GaussianSource` `fwhm` field from `Double` to an `Angle`.  FWHM is understood to be expressed in arcsec so this update just tightens the type a bit from `Double` to `Angle`.  This will make the x-binning calculation easier since the object size will be taken from the `fwhm` field.

Along the same lines, this PR also updates the slit effective width to an `Angle` instead of `Double` understood to be in arcsec.