### PR TITLE
X binning update

### DIFF
--- a/src/main/scala/ObservingConditions.scala
+++ b/src/main/scala/ObservingConditions.scala
@@ -1,0 +1,27 @@
+// Copyright (c) 2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package basic
+
+import basic.enum._
+
+import cats._
+
+/**
+ * Observing conditions.
+ */
+final case class ObservingConditions(
+  cc: CloudCover,
+  iq: ImageQuality,
+  sb: SkyBackground,
+  wv: WaterVapor
+)
+
+object ObservingConditions {
+
+  implicit val EqObservingConditions: Eq[ObservingConditions] =
+    Eq.instance { (a, b) =>
+      // TODO: when we have Enumerated instances for these, we can use ===
+      (a.cc == b.cc) && (a.iq == b.iq) && (a.sb == b.sb) && (a.wv == b.wv)
+    }
+}

--- a/src/main/scala/gen/gmos/GmosLongslitException.scala
+++ b/src/main/scala/gen/gmos/GmosLongslitException.scala
@@ -1,0 +1,10 @@
+// Copyright (c) 2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package basic.gen.gmos
+
+/**
+ * Exception raised during GMOS longslit sequence calculation.
+ */
+final case class GmosLongslitException(problem: GmosLongslitProblem)
+  extends RuntimeException(problem.message)

--- a/src/main/scala/gen/gmos/GmosLongslitProblem.scala
+++ b/src/main/scala/gen/gmos/GmosLongslitProblem.scala
@@ -1,0 +1,43 @@
+// Copyright (c) 2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package basic
+package gen.gmos
+
+import basic.enum.ImageQuality
+import gem.enum.GmosXBinning
+
+import fs2._
+
+/**
+ * Possible issues that may arise as a sequence is calculated.
+ */
+sealed trait GmosLongslitProblem extends Product with Serializable {
+  def message: String
+
+  def exception: GmosLongslitException =
+    GmosLongslitException(this)
+
+  def raiseError[F[_]: RaiseThrowable]: Stream[F, INothing] =
+    Stream.raiseError(exception)
+}
+
+object GmosLongslitProblem {
+
+  final case class BinningChange(
+    from: GmosXBinning,
+    to:   GmosXBinning,
+    iq:   ImageQuality
+  ) extends GmosLongslitProblem {
+    override def message: String =
+      s"GMOS X Binning would need to be updated to ${to.count} from ${from.count} in IQ${iq.percentage}"
+  }
+
+  final case class SourceTooBright(
+    conditions: ObservingConditions
+  ) extends GmosLongslitProblem {
+    override def message: String =
+      s"The ITC reports that the source is too bright to be observed in CC${conditions.cc.percentage}, IQ${conditions.iq.percentage}, and SB${conditions.sb.percentage}"
+  }
+
+}

--- a/src/main/scala/gen/gmos/GmosNLongslit.scala
+++ b/src/main/scala/gen/gmos/GmosNLongslit.scala
@@ -1,9 +1,11 @@
 // Copyright (c) 2019 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package basic.gen.gmos
+package basic
+package gen.gmos
 
-import basic.ObservingMode
+import basic.enum.ImageQuality
+import basic.misc.SpatialProfile
 import basic.syntax.all._
 
 import gem.Step
@@ -32,7 +34,11 @@ sealed trait GmosNLongslit {
    * mini-sequence containing steps that must be executed together. The
    * sequence should be stopped when the desired S/N ratio has been met.
    */
-  def science(e: Duration): Stream[Pure, Stream[Pure, Step.GmosN]]
+  def science(
+    e:  Duration,
+    sp: SpatialProfile,
+    iq: ImageQuality
+  ): Stream[Pure, Stream[Pure, Step.GmosN]]
 
 }
 
@@ -78,7 +84,11 @@ object GmosNLongslit {
 
       }
 
-      override def science(e: Duration): Stream[Pure, Stream[Pure, Step.GmosN]] = {
+      override def science(
+        e:  Duration,
+        sp: SpatialProfile,
+        iq: ImageQuality
+      ): Stream[Pure, Stream[Pure, Step.GmosN]] = {
 
         // Adds two wavelength values. This is unsafe in general because of the
         // possibility of overflow.  Here we know that Δ is at most 30 nm and λ is
@@ -89,7 +99,7 @@ object GmosNLongslit {
         eval {
           for {
             _  <- GmosN.exposureTime := e
-            _  <- GmosN.xBinning     := xbin(mode.fpu)
+            _  <- GmosN.xBinning     := xbin(mode.fpu, sp, iq)
             _  <- GmosN.yBinning     := GmosYBinning.Two
             _  <- GmosN.grating      := Some(GmosGrating(mode.disperser, GmosDisperserOrder.One, mode.λ))
             _  <- GmosN.filter       := mode.filter

--- a/src/main/scala/gen/gmos/GmosNLongslitD.scala
+++ b/src/main/scala/gen/gmos/GmosNLongslitD.scala
@@ -6,6 +6,7 @@ package gen.gmos
 
 import basic.syntax.all._
 import basic.enum.ImageQuality
+import basic.gen.gmos.GmosLongslitProblem._
 import basic.misc.SpatialProfile
 
 import gem.Step
@@ -333,16 +334,30 @@ object GmosNLongslitD {
         reachedS2N: Int => F[Boolean]
       ): Stream[F, Stream[F, (Step.GmosN, Double)]] = {
 
+        // Ensures that the x-binning setting would not change under the current
+        // observing conditions and that the ITC result is valid.  If so uses
+        // the given function to compute the stream.
+        def ifValid(
+          c: ObservingConditions,
+          i: Itc.Result,
+          s: Step.GmosN
+        )(f: Itc.Result.Success => Stream[F, (Step.GmosN, Double)]) = {
+          val from = GmosN.xBinning.get(s.dynamicConfig)
+          val to   = xbin(observingMode.fpu, targetProfile.spatialProfile, c.iq)
+          if (from =!= to)
+            BinningChange(from, to, c.iq).raiseError[F]
+          else i match {
+            case s @ Itc.Result.Success(_, _, _) => f(s)
+            case Itc.Result.SourceTooBright      => SourceTooBright(c).raiseError[F]
+          }
+        }
+
         // Updates science step exposure time and adds this step's contribution
         // to total s/n.
         def applyItc(step: Step.GmosN, s: Itc.Result.Success): (Step.GmosN, Double) =
           step match {
-
-            case Step.GmosN(_, Science(_)) =>
-              (exposureTime.optional.set(s.exposureTime)(step), s.stepSignalToNoise)
-
-            case _                         =>
-              (step, 0.0)
+            case Step.GmosN(_, Science(_)) => (exposureTime.optional.set(s.exposureTime)(step), s.stepSignalToNoise)
+            case _                         => (step, 0.0)
           }
 
         // A mini stream containing two steps, one a science dataset and the
@@ -350,15 +365,14 @@ object GmosNLongslitD {
         // we'll make the nested stream visible to the caller.
         def substream(a: Step.GmosN, b: Step.GmosN): Stream[F, (Step.GmosN, Double)] =
           Stream.force {
-            itc.calculate(targetProfile, observingMode, signalToNoise).map {
 
-              case s @ Itc.Result.Success(_, _, _) =>
-                Stream(applyItc(a, s), applyItc(b, s)).covary[F]
-
-              case Itc.Result.SourceTooBright =>
-                // TODO: error cases
-                Stream.raiseError[F](new RuntimeException("source too bright"))
+            for {
+              c <- conditions
+              i <- itc.calculate(targetProfile, observingMode, signalToNoise)
+            } yield ifValid(c, i, a) { success =>
+                Stream(applyItc(a, success), applyItc(b, success)).covary[F]
             }
+
           }
 
         Stream.force {

--- a/src/main/scala/itc/ItcSourceDefinition.scala
+++ b/src/main/scala/itc/ItcSourceDefinition.scala
@@ -48,9 +48,12 @@ object ItcSourceDefinition {
       import SpatialProfile._
       def apply(a: SpatialProfile): Json =
         a match {
-          case PointSource          => Json.obj("PointSource"    -> Json.obj())
-          case UniformSource        => Json.obj("UniformSource"  -> Json.obj())
-          case GaussianSource(fwhm) => Json.obj("GaussianSource" -> Json.obj("fwhm" -> Json.fromDoubleOrNull(fwhm)))
+          case PointSource           => Json.obj("PointSource"    -> Json.obj())
+          case UniformSource         => Json.obj("UniformSource"  -> Json.obj())
+          case g @ GaussianSource(_) =>
+            Json.obj(
+              "GaussianSource" -> Json.obj("fwhm" -> Json.fromDoubleOrNull(GaussianSource.arcsec.get(g).toDouble))
+            )
         }
     }
 

--- a/src/main/scala/misc/SpatialProfile.scala
+++ b/src/main/scala/misc/SpatialProfile.scala
@@ -3,9 +3,40 @@
 
 package basic.misc
 
+import gem.math.Angle
+import gem.optics.SplitMono
+
 sealed trait SpatialProfile
+
 object SpatialProfile {
-  final case object PointSource                  extends SpatialProfile
-  final case object UniformSource                extends SpatialProfile
-  final case class  GaussianSource(fwhm: Double) extends SpatialProfile
+  final case object PointSource                 extends SpatialProfile
+  final case object UniformSource               extends SpatialProfile
+
+  /**
+   * Gaussian source. For a good discussion of seeing see the
+   * ["Astronomical seeing" wikipedia entry](https://en.wikipedia.org/wiki/Astronomical_seeing).
+   *
+   * @param fwhm full width at half maximum of the seeing disc (typically
+   *             in arcsec)
+   */
+  final case class  GaussianSource(fwhm: Angle) extends SpatialProfile
+
+  object GaussianSource extends GaussianSourceOptics
+
+  trait GaussianSourceOptics {
+
+    /**
+     * Conversion between GaussianSource and arcsec of the FWHM of the seeing
+     * disc.
+     *
+     * @group Optics
+     */
+    val arcsec: SplitMono[GaussianSource, BigDecimal] =
+      SplitMono(
+        g => new java.math.BigDecimal(g.fwhm.toMicroarcseconds).movePointLeft(6),
+        d => GaussianSource(Angle.fromMicroarcseconds(d.underlying.movePointRight(6).longValue))
+      )
+
+  }
 }
+

--- a/src/main/scala/syntax/GmosNorthDisperser.scala
+++ b/src/main/scala/syntax/GmosNorthDisperser.scala
@@ -5,7 +5,7 @@ package basic.syntax
 
 import gem.enum.GmosNorthDisperser
 import gem.enum.GmosNorthDisperser._
-import gem.math.Wavelength
+import gem.math.{ Angle, Wavelength }
 
 /**
  * Syntax extensions for missing properties. These need to be folded back into the Gem enumerations.
@@ -38,8 +38,8 @@ final class GmosNorthDisperserOps(val self: GmosNorthDisperser) extends AnyVal {
   }
 
   /** Resolution at λ with the specified slit width (arcsec). */
-  def resolution(λ: Wavelength, slitWidth: Double): Int =
-    ((Wavelength.fromNanometers.reverseGet(λ) / Δλ) * (0.5 / slitWidth)).toInt
+  def resolution(λ: Wavelength, slitWidth: Angle): Int =
+    ((Wavelength.fromNanometers.reverseGet(λ) / Δλ) * (0.5 / Angle.signedArcseconds.get(slitWidth))).toInt
 
   /**
    * Simultaneous coverage with Hamamatsu detectors.

--- a/src/main/scala/syntax/GmosNorthFpu.scala
+++ b/src/main/scala/syntax/GmosNorthFpu.scala
@@ -6,29 +6,31 @@ package basic.syntax
 import gem.enum.GmosNorthFpu
 import gem.enum.GmosNorthFpu._
 
+import gem.math.Angle
+
 /**
  * Syntax extensions for missing properties. These need to be folded back into the Gem enumerations.
  */
 final class GmosNorthFpuOps(val self: GmosNorthFpu) extends AnyVal {
 
-  def effectiveSlitWidth: Double =
+  def effectiveSlitWidth: Angle =
     self match {
-      case Ifu1          => 0.31
-      case Ifu2          => 0.31
-      case Ifu3          => 0.31
-      case Ns0           => 0.25
-      case Ns1           => 0.50
-      case Ns2           => 0.75
-      case Ns3           => 1.00
-      case Ns4           => 1.50
-      case Ns5           => 2.00
-      case LongSlit_0_25 => 0.25
-      case LongSlit_0_50 => 0.50
-      case LongSlit_0_75 => 0.75
-      case LongSlit_1_00 => 1.00
-      case LongSlit_1_50 => 1.50
-      case LongSlit_2_00 => 2.00
-      case LongSlit_5_00 => 5.00
+      case Ifu1          => Angle.fromMicroarcseconds( 310000)
+      case Ifu2          => Angle.fromMicroarcseconds( 310000)
+      case Ifu3          => Angle.fromMicroarcseconds( 310000)
+      case Ns0           => Angle.fromMicroarcseconds( 250000)
+      case Ns1           => Angle.fromMicroarcseconds( 500000)
+      case Ns2           => Angle.fromMicroarcseconds( 750000)
+      case Ns3           => Angle.fromMicroarcseconds(1000000)
+      case Ns4           => Angle.fromMicroarcseconds(1500000)
+      case Ns5           => Angle.fromMicroarcseconds(2000000)
+      case LongSlit_0_25 => Angle.fromMicroarcseconds( 250000)
+      case LongSlit_0_50 => Angle.fromMicroarcseconds( 500000)
+      case LongSlit_0_75 => Angle.fromMicroarcseconds( 750000)
+      case LongSlit_1_00 => Angle.fromMicroarcseconds(1000000)
+      case LongSlit_1_50 => Angle.fromMicroarcseconds(1500000)
+      case LongSlit_2_00 => Angle.fromMicroarcseconds(2000000)
+      case LongSlit_5_00 => Angle.fromMicroarcseconds(5000000)
     }
 
   def isNodAndShuffle: Boolean =

--- a/src/main/scala/syntax/GmosNorthFpu.scala
+++ b/src/main/scala/syntax/GmosNorthFpu.scala
@@ -33,6 +33,26 @@ final class GmosNorthFpuOps(val self: GmosNorthFpu) extends AnyVal {
       case LongSlit_5_00 => Angle.fromMicroarcseconds(5000000)
     }
 
+  def isIfu: Boolean =
+    self match {
+      case Ifu1          => true
+      case Ifu2          => true
+      case Ifu3          => true
+      case Ns0           => false
+      case Ns1           => false
+      case Ns2           => false
+      case Ns3           => false
+      case Ns4           => false
+      case Ns5           => false
+      case LongSlit_0_25 => false
+      case LongSlit_0_50 => false
+      case LongSlit_0_75 => false
+      case LongSlit_1_00 => false
+      case LongSlit_1_50 => false
+      case LongSlit_2_00 => false
+      case LongSlit_5_00 => false
+    }
+
   def isNodAndShuffle: Boolean =
     self match {
       case Ifu1          => false


### PR DESCRIPTION
Updates GMOS longslit sequence generation to account for image quality and target size when computing the x-binning value.  Along the way it updates the `Gaussian` spatial profile `fwhm` field to `Angle` instead of a raw `Double` (since it is a value in arcsec) and updates the FPU `effectiveSlitWidth` to an `Angle` instead of a `Double` as well.

This PR subsumes #18.