### PR TITLE
clip coverage to filter limits

### DIFF
--- a/src/main/scala/ObservingMode.scala
+++ b/src/main/scala/ObservingMode.scala
@@ -4,6 +4,7 @@
 package basic
 
 import basic.syntax.all._
+import basic.misc._
 import gem.enum._
 import gem.math.Wavelength
 
@@ -14,9 +15,9 @@ sealed trait ObservingMode {
 object ObservingMode {
 
   sealed trait Spectroscopy extends ObservingMode {
-    def λ:                    Wavelength
-    def resolution:           Int
-    def simultaneousCoverage: Wavelength
+    def λ:          Wavelength
+    def resolution: Int
+    def coverage:   Coverage
   }
 
   object Spectroscopy {
@@ -34,8 +35,8 @@ object ObservingMode {
       def resolution: Int =
         disperser.resolution(λ, fpu.effectiveSlitWidth)
 
-      def simultaneousCoverage: Wavelength =
-        disperser.simultaneousCoverage
+      def coverage: Coverage =
+        filter.foldLeft(disperser.coverage(λ))(_ ⋂ _.coverage)
 
     }
 

--- a/src/main/scala/graphql/schema/CoverageType.scala
+++ b/src/main/scala/graphql/schema/CoverageType.scala
@@ -1,0 +1,42 @@
+// Copyright (c) 2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package basic.graphql.schema
+
+import basic.misc.Coverage
+import sangria.schema._
+
+object CoverageType {
+
+  val range: ObjectType[Unit, Coverage.Range] =
+    ObjectType(
+      name        = "CoverageRange",
+      description = "Coverage over a specified range of wavelengths.",
+      fields = fields(
+
+        Field(
+          name        = "min",
+          fieldType   = WavelengthType.scalar,
+          description = Some("Minimum wavelength."),
+          resolve     = _.value.min
+        ),
+
+        Field(
+          name        = "max",
+          fieldType   = WavelengthType.scalar,
+          description = Some("Maximum wavelength."),
+          resolve     = _.value.max
+        ),
+
+        Field(
+          name        = "width",
+          fieldType   = WavelengthType.scalar,
+          description = Some("Simultaneous coverage."),
+          resolve     = _.value.width
+        ),
+
+        )
+    )
+
+
+}

--- a/src/main/scala/graphql/schema/ObservingModeType.scala
+++ b/src/main/scala/graphql/schema/ObservingModeType.scala
@@ -47,10 +47,10 @@ object ObservingModeType {
         ),
 
         Field(
-          name        = "simultaneousCoverage",
-          description = Some("Simultaneous wavelength coverage."),
-          fieldType   = WavelengthType.scalar,
-          resolve     = _.value.simultaneousCoverage
+          name        = "coverage",
+          description = Some("Wavelength coverage."),
+          fieldType   = OptionType(CoverageType.range),
+          resolve     = _.value.coverage.range
         ),
 
         Field(

--- a/src/main/scala/misc/Coverage.scala
+++ b/src/main/scala/misc/Coverage.scala
@@ -4,6 +4,7 @@ import basic.syntax.wavelength._
 import cats.implicits._
 import gem.math.Wavelength
 
+/** Wavelength coverage. */
 sealed trait Coverage {
   import Coverage.{ Empty, Range }
 
@@ -12,15 +13,17 @@ sealed trait Coverage {
     (this, other) match {
       case (Empty, _) => Empty
       case (_, Empty) => Empty
-      case (Range(a, b), Range(aʹ, bʹ)) => new Range(a max aʹ, b min bʹ) {}
+      case (Range(a, b), Range(aʹ, bʹ)) => Coverage(a max aʹ, b min bʹ)
     }
 
+  /** Coverage width; i.e., difference between max and min (or zero). */
   def width: Wavelength =
     this match {
       case Empty       => Wavelength.Min
       case Range(a, b) => b - a
     }
 
+  /** Range projection; defined when non-empty. */
   def range: Option[Coverage.Range] =
     this match {
       case Empty              => None
@@ -31,15 +34,19 @@ sealed trait Coverage {
 
 object Coverage {
 
+  /** The empty `Coverage` with no bounds and a width of zero. */
   case object Empty extends Coverage
 
+  /** Non-empty `Coverage` with upper and lower bounds. */
   sealed abstract case class Range(min: Wavelength, max: Wavelength) extends Coverage {
-    require(min <= max) // smart ctor should guarantee this
+    require(min < max) // smart ctor should guarantee this
   }
 
+  /** Construct a `Coverage`, empty if `min >= max`. */
   def apply(min: Wavelength, max: Wavelength): Coverage =
-    if (min > max) Empty else new Range(min, max) {}
+    if (min < max) new Range(min, max) {} else Empty
 
+  /** Conctruct a `Coverage` centered at the given wavelength, with the specified width. */
   def centered(central: Wavelength, width: Wavelength): Coverage =
     apply(central - width / 2, central + width / 2)
 

--- a/src/main/scala/misc/Coverage.scala
+++ b/src/main/scala/misc/Coverage.scala
@@ -1,0 +1,46 @@
+package basic.misc
+
+import basic.syntax.wavelength._
+import cats.implicits._
+import gem.math.Wavelength
+
+sealed trait Coverage {
+  import Coverage.{ Empty, Range }
+
+  /** Intersect this `Coverage` with another. */
+  def ⋂(other: Coverage): Coverage =
+    (this, other) match {
+      case (Empty, _) => Empty
+      case (_, Empty) => Empty
+      case (Range(a, b), Range(aʹ, bʹ)) => new Range(a max aʹ, b min bʹ) {}
+    }
+
+  def width: Wavelength =
+    this match {
+      case Empty       => Wavelength.Min
+      case Range(a, b) => b - a
+    }
+
+  def range: Option[Coverage.Range] =
+    this match {
+      case Empty              => None
+      case r @ Range(_, _) => Some(r)
+    }
+
+}
+
+object Coverage {
+
+  case object Empty extends Coverage
+
+  sealed abstract case class Range(min: Wavelength, max: Wavelength) extends Coverage {
+    require(min <= max) // smart ctor should guarantee this
+  }
+
+  def apply(min: Wavelength, max: Wavelength): Coverage =
+    if (min > max) Empty else new Range(min, max) {}
+
+  def centered(central: Wavelength, width: Wavelength): Coverage =
+    apply(central - width / 2, central + width / 2)
+
+}

--- a/src/main/scala/misc/Coverage.scala
+++ b/src/main/scala/misc/Coverage.scala
@@ -1,3 +1,6 @@
+// Copyright (c) 2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
 package basic.misc
 
 import basic.syntax.wavelength._
@@ -46,8 +49,10 @@ object Coverage {
   def apply(min: Wavelength, max: Wavelength): Coverage =
     if (min < max) new Range(min, max) {} else Empty
 
-  /** Conctruct a `Coverage` centered at the given wavelength, with the specified width. */
-  def centered(central: Wavelength, width: Wavelength): Coverage =
-    apply(central - width / 2, central + width / 2)
+  /** Construct a `Coverage` centered at the given wavelength, with the specified width. */
+  def centered(central: Wavelength, width: Wavelength): Coverage = {
+    val half = Wavelength.fromPicometers.getOption(width.toPicometers / 2).get // always positive
+    apply(central - half, central + half)
+  }
 
 }

--- a/src/main/scala/search/Search.scala
+++ b/src/main/scala/search/Search.scala
@@ -56,8 +56,8 @@ object Search {
     // Now filter down the list.
     val compatibleModes: List[ObservingMode.Spectroscopy] =
       allModes
-        .filter(_.simultaneousCoverage >= constraints.simultaneousCoverage)
-        .filter(_.resolution >= constraints.resolution)
+        .filter(_.coverage.width >= constraints.simultaneousCoverage)
+        .filter(_.resolution     >= constraints.resolution)
 
     // Done!
     compatibleModes.parTraverse { mode =>

--- a/src/main/scala/syntax/GmosNorthDisperser.scala
+++ b/src/main/scala/syntax/GmosNorthDisperser.scala
@@ -3,6 +3,7 @@
 
 package basic.syntax
 
+import basic.misc.Coverage
 import gem.enum.GmosNorthDisperser
 import gem.enum.GmosNorthDisperser._
 import gem.math.{ Angle, Wavelength }
@@ -56,6 +57,10 @@ final class GmosNorthDisperserOps(val self: GmosNorthDisperser) extends AnyVal {
       case R150_G5306  => Wavelength.fromNanometers.unsafeGet(1071) // obsolete, value with old e2v detector
       case R150_G5308  => Wavelength.fromNanometers.unsafeGet(1219)
     }
+
+  /** Compute the coverage of this disperser, given a central wavelength. */
+  def coverage(λ: Wavelength): Coverage =
+    Coverage.centered(λ, simultaneousCoverage)
 
   /**
    * Dispersion (pm/pixel) with Hamamatsu detectors.

--- a/src/main/scala/syntax/GmosNorthFilter.scala
+++ b/src/main/scala/syntax/GmosNorthFilter.scala
@@ -3,10 +3,11 @@
 
 package basic.syntax
 
+import basic.misc.Coverage
+import cats.implicits._
 import gem.enum.GmosNorthFilter
 import gem.enum.GmosNorthFilter._
-
-import cats.implicits._
+import gem.math.Wavelength
 
 final class GmosNorthFilterOps(val self: GmosNorthFilter) extends AnyVal {
 
@@ -40,7 +41,57 @@ final class GmosNorthFilterOps(val self: GmosNorthFilter) extends AnyVal {
       case UPrime           => "u_G0308"
     }
 
+  // see http://www.gemini.edu/node/10621
+  def coverage: Coverage = {
+    import Wavelength.fromPicometers
+
+    def cov(a: Int, b: Int = Int.MaxValue): Coverage =
+      (fromPicometers.getOption(a), fromPicometers.getOption(b))
+        .mapN(Coverage.apply)
+        .getOrElse(sys.error("Invalid constant coverage."))
+
+    self match {
+
+      // Broad Band Imaging Filters
+      case UPrime           => cov(336000,  385000)
+      case GPrime           => cov(398000,  552000)
+      case RPrime           => cov(562000,  698000)
+      case IPrime           => cov(706000,  850000)
+      case CaT              => cov(780000,  993000)
+      case ZPrime           => cov(848000)
+      case Z                => cov(830000,  925000)
+      case Y                => cov(970000, 1070000)
+
+      // Narrow Band Imaging Filters
+      case HeII             => cov(464000,  472000)
+      case HeIIC            => cov(474000,  482000)
+      case OIII             => cov(496500,  501500)
+      case OIIIC            => cov(509000,  519000)
+      case Ha               => cov(654000,  661000)
+      case HaC              => cov(659000,  665000)
+      case SII              => cov(669400,  673700)
+      // OVIC? OVI?
+      case DS920            => cov(912800,  931400)
+
+      // Spectroscopy Blocking Filters
+      case GG455            => cov(460000)
+      case OG515            => cov(520000)
+      case RG610            => cov(615000)
+
+      case HartmannA_RPrime => ??? // hmmmmm
+      case HartmannB_RPrime => ???
+
+      // Allowed Filter Combinations
+      case GPrime_GG455     => cov(460000,  552000)
+      case GPrime_OG515     => cov(520000,  552000)
+      case RPrime_RG610     => cov(615000,  698000)
+      case IPrime_CaT       => cov(780000,  850000)
+      case ZPrime_CaT       => cov(848000,  933000)
+    }
+  }
+
 }
+
 
 trait ToGmosNorthFilterOps {
   implicit def toGmosNorthFilterOps(self: GmosNorthFilter): GmosNorthFilterOps =

--- a/src/main/scala/syntax/GmosNorthFilter.scala
+++ b/src/main/scala/syntax/GmosNorthFilter.scala
@@ -61,6 +61,7 @@ final class GmosNorthFilterOps(val self: GmosNorthFilter) extends AnyVal {
       case ZPrime           => cov(848000)
       case Z                => cov(830000,  925000)
       case Y                => cov(970000, 1070000)
+      // ri -- not in OCS3 … need to add
 
       // Narrow Band Imaging Filters
       case HeII             => cov(464000,  472000)
@@ -70,7 +71,7 @@ final class GmosNorthFilterOps(val self: GmosNorthFilter) extends AnyVal {
       case Ha               => cov(654000,  661000)
       case HaC              => cov(659000,  665000)
       case SII              => cov(669400,  673700)
-      // OVIC? OVI?
+      // OVIC? OVI? -- these aren't in OCS3 … need to add
       case DS920            => cov(912800,  931400)
 
       // Spectroscopy Blocking Filters
@@ -78,8 +79,10 @@ final class GmosNorthFilterOps(val self: GmosNorthFilter) extends AnyVal {
       case OG515            => cov(520000)
       case RG610            => cov(615000)
 
-      case HartmannA_RPrime => ??? // hmmmmm
-      case HartmannB_RPrime => ???
+      // These are only used for engineering and will never be selected by search algorithm, but
+      // we still need to handle them. For now we'll just pretend they have no coverage at all.
+      case HartmannA_RPrime => Coverage.Empty
+      case HartmannB_RPrime => Coverage.Empty
 
       // Allowed Filter Combinations
       case GPrime_GG455     => cov(460000,  552000)

--- a/src/main/scala/syntax/Wavelength.scala
+++ b/src/main/scala/syntax/Wavelength.scala
@@ -20,9 +20,6 @@ final class WavelengthOps(val self: Wavelength) extends AnyVal {
       .flatMap(Wavelength.fromPicometers.getOption)
       .getOrElse(Wavelength.Max)
 
-  def /(scalar: Int): Wavelength =
-    Wavelength.fromPicometers.getOption(self.toPicometers / scalar).get // always positive
-
 }
 
 trait ToWavelengthOps {

--- a/src/main/scala/syntax/Wavelength.scala
+++ b/src/main/scala/syntax/Wavelength.scala
@@ -1,0 +1,33 @@
+// Copyright (c) 2019 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package basic.syntax
+
+import gem.math.Wavelength
+
+final class WavelengthOps(val self: Wavelength) extends AnyVal {
+
+  /** Returns the difference of this wavelength and `other`, clipped at Wavelength.Min. */
+  def -(other: Wavelength): Wavelength =
+    Wavelength.fromPicometers.getOption(self.toPicometers - other.toPicometers)
+      .getOrElse(Wavelength.Min)
+
+  /** Returns the sum of this wavelength and `other`, clipped at Wavelength.Max. */
+  def +(other: Wavelength): Wavelength =
+    Some(BigInt(self.toPicometers) + BigInt(other.toPicometers))
+      .filter(_.isValidInt)
+      .map(_.toInt)
+      .flatMap(Wavelength.fromPicometers.getOption)
+      .getOrElse(Wavelength.Max)
+
+  def /(scalar: Int): Wavelength =
+    Wavelength.fromPicometers.getOption(self.toPicometers / scalar).get // always positive
+
+}
+
+trait ToWavelengthOps {
+  implicit def toWavelengthOps(self: Wavelength): WavelengthOps =
+    new WavelengthOps(self)
+}
+
+object wavelength extends ToWavelengthOps

--- a/src/main/scala/syntax/package.scala
+++ b/src/main/scala/syntax/package.scala
@@ -24,5 +24,6 @@ package object syntax {
        with ToMoreStateLensOps
        with ToMoreStateOptionalOps
        with ToNumericOps
+       with ToWavelengthOps
 
 }

--- a/src/test/scala/misc/CoverageSuite.scala
+++ b/src/test/scala/misc/CoverageSuite.scala
@@ -1,0 +1,58 @@
+package basic.misc
+
+
+import cats.tests._
+import gem.math.Wavelength
+import org.scalacheck._
+import org.scalacheck.Arbitrary._
+
+class CoverageSuite extends CatsSuite {
+
+  implicit def arbWavelength: Arbitrary[Wavelength] =
+    Arbitrary {
+      arbitrary[Int].map(_.abs).map(Wavelength.fromPicometers.getOption).flatMap {
+        case Some(w) => Gen.const(w)
+        case None    => Gen.fail
+      }
+    }
+
+  implicit def arbCoverage: Arbitrary[Coverage] =
+    Arbitrary {
+      for {
+        a <- arbitrary[Wavelength]
+        b <- arbitrary[Wavelength]
+      } yield Coverage(a, b)
+    }
+
+  test("construction.invariant") {
+    forAll { (a: Wavelength, b: Wavelength) =>
+      Coverage(a, b).range.isDefined should be (a < b)
+    }
+  }
+
+  test("intersection.identity") {
+    forAll { (a: Coverage) =>
+      (a ⋂ a) should be (a)
+    }
+  }
+
+  test("intersection.annihilation.right") {
+    forAll { (a: Coverage) =>
+      (a ⋂ Coverage.Empty) should be (Coverage.Empty)
+    }
+  }
+
+  test("intersection.annihilation.left") {
+    forAll { (a: Coverage) =>
+      (Coverage.Empty ⋂ a) should be (Coverage.Empty)
+    }
+  }
+
+  test("intersection.reduction") {
+    forAll { (a: Coverage, b: Coverage) =>
+      (a ⋂ b).width should be <= a.width
+      (a ⋂ b).width should be <= b.width
+    }
+  }
+
+}


### PR DESCRIPTION
This improves the simultaneous coverage calculation by intersecting the grating's coverage with the filter's coverage. We now report the coverage min/max in the GraphQL interface.